### PR TITLE
Remove optional "Home Sample" Launcher

### DIFF
--- a/target/product/core_base.mk
+++ b/target/product/core_base.mk
@@ -23,7 +23,6 @@ PRODUCT_PROPERTY_OVERRIDES := \
 PRODUCT_PACKAGES += \
     ContactsProvider \
     DefaultContainerService \
-    Home \
     TelephonyProvider \
     UserDictionaryProvider \
     atrace \


### PR DESCRIPTION
Built for Grouper last night and on first boot to home screen there were two launcher options ("Home Sample" and "Launcher").
This commit removes "Home Sample"
