### PR TITLE
 gettop: fix symlink detection

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -614,7 +614,7 @@ function gettop
             T=
             while [ \( ! \( -f $TOPFILE \) \) -a \( $PWD != "/" \) ]; do
                 \cd ..
-                T=`PWD= /bin/pwd`
+                T=`PWD= /bin/pwd -P`
             done
             \cd $HERE
             if [ -f "$T/$TOPFILE" ]; then


### PR DESCRIPTION
"We must use the -P flag for pwd to properly get $PWD from the environment _with_ symlinks. Otherwise symlink
detection is broken and anything we do using $(gettop) at the top of a symlinked path won't work properly. I noticed this
issue while running on a system that has a SSD RAID symlinked to my android build home directory, which is ~/ssd_storage.
The top in this instance is a symlink, which means that gettop() returns my home path, or the path above the symlink
directory (but not the symlinked directory). This is a major issue in case developers choose to use $(gettop),
$ANDROID_BUILD_TOP, or $T (doesn't really matter either way).

Test Plan: Create a symlink and sync android source into the path. Open up the symlink, run envsetup.sh, and check
$(gettop) output.

While this isn't the best solution, it fixes an issue without creating new issues."
Taken from AOSP gerrit, where its been merged
https://android-review.googlesource.com/#/c/61781/
